### PR TITLE
Host documentation only in one place on meshlib.io/documentation fix for Dev documentation

### DIFF
--- a/scripts/analytics/html_head.html
+++ b/scripts/analytics/html_head.html
@@ -1,8 +1,10 @@
 <script type="text/javascript">
   !function () {
     var currentHost = window.location.hostname;
-    if (currentHost === 'meshinspector.github.io') {
-      var newPath = window.location.pathname.replace('/MeshLib/html', '/documentation');
+    var currentPath = window.location.pathname;
+
+    if (currentHost === 'meshinspector.github.io' && !currentPath.includes('/MeshLib/dev/html')) {
+      var newPath = currentPath.replace('/MeshLib/html', '/documentation');
       var newURL = 'https://meshlib.io' + newPath + window.location.search + window.location.hash;
       window.location.replace(newURL);
     }


### PR DESCRIPTION
This is to temporarily prevent the redirection from https://meshinspector.github.io/MeshLib/dev/html/index.html to meshlib.io.