### PR TITLE
Add a canonical link for each page in documentation. Fix path to script

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -10,7 +10,7 @@ rm html_header.html html_footer.html html_stylesheet.css
 TARGET_DIR="${1:-MeshLib}"
 URL_PREFIX="${2:-https://meshlib.io/documentation}"
 
-BASE_DIR=$(realpath $(dirname "$0"))
+BASE_DIR=$(dirname "$0")
 
 # Conditionally run update_canonical.sh if TARGET_DIR is not "MeshLib/dev"
 if [ "$TARGET_DIR" != "MeshLib/dev" ]; then


### PR DESCRIPTION
This is small change to fix path for GitHub actions. The main PR is:
- #6