### PR TITLE
Add a canonical link for each page in documentation. Fix path to script third try

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -10,9 +10,7 @@ rm html_header.html html_footer.html html_stylesheet.css
 TARGET_DIR="${1:-MeshLib}"
 URL_PREFIX="${2:-https://meshlib.io/documentation}"
 
-BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
-
 # Conditionally run update_canonical.sh if TARGET_DIR is not "MeshLib/dev"
 if [ "$TARGET_DIR" != "MeshLib/dev" ]; then
-  "$BASE_DIR"/update_canonical.sh "$TARGET_DIR/html" "$URL_PREFIX"
+  ./scripts/update_canonical.sh "$TARGET_DIR/html" "$URL_PREFIX"
 fi


### PR DESCRIPTION
This is small change to fix path for GitHub actions. The main PR is:
- #6

Previous tries:
- #7
- #8