### PR TITLE
show inherited Const_* methods inline on C# class pages

### DIFF
--- a/DoxyfileCsharp
+++ b/DoxyfileCsharp
@@ -2,6 +2,7 @@
 
 PROJECT_NAME           = "MeshLib C# Docs"
 LAYOUT_FILE            = ../MeshLib/doxygen/DoxygenLayoutCsharp.xml
+INLINE_INHERITED_MEMB  = YES
 INPUT                  = ../MeshLib/CsharpBindings/ \
                          ../MeshLib/doxygen/APICsharpPage.dox
 EXCLUDE                = ../MeshLib/CsharpBindings/MRCMisc \


### PR DESCRIPTION
mrbind splits each C# class into `Const_Foo` (read-only methods) and `Foo : Const_Foo` (mutating). `DoxyfileCsharp` hides `Const_*` via `EXCLUDE_SYMBOLS`, so their methods render as an "inherited from Const_Foo" section that links nowhere — the read-only methods effectively vanish from `Foo`'s page.

`INLINE_INHERITED_MEMB = YES` inlines them directly onto `Foo`. Module-local (not set in `DoxyfileBase` or other per-language files), so C++/Py/C docs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)