### PR TITLE
expose Const_* classes in C# docs

### DIFF
--- a/DoxyfileCsharp
+++ b/DoxyfileCsharp
@@ -2,7 +2,6 @@
 
 PROJECT_NAME           = "MeshLib C# Docs"
 LAYOUT_FILE            = ../MeshLib/doxygen/DoxygenLayoutCsharp.xml
-INLINE_INHERITED_MEMB  = YES
 INPUT                  = ../MeshLib/CsharpBindings/ \
                          ../MeshLib/doxygen/APICsharpPage.dox
 EXCLUDE                = ../MeshLib/CsharpBindings/MRCMisc \
@@ -13,4 +12,4 @@ HTML_OUTPUT            = html/Csharp
 
 # For C# projects
 EXTRACT_STATIC         = YES
-EXCLUDE_SYMBOLS        = Json std Const_* Mut_* _A* _B* _C* _D* _E* _F* _G* _H* _I* _J* _K* _L* _M* _N* _O* _P* _Q* _R* _S* _T* _U* _V* _W* _X* _Y* _Z*
+EXCLUDE_SYMBOLS        = Json std Mut_* _A* _B* _C* _D* _E* _F* _G* _H* _I* _J* _K* _L* _M* _N* _O* _P* _Q* _R* _S* _T* _U* _V* _W* _X* _Y* _Z*


### PR DESCRIPTION
PR #32's `INLINE_INHERITED_MEMB = YES` had no effect for `Mesh` / `PointCloud` / etc. — Doxygen drops members of EXCLUDE_SYMBOLS-matched classes entirely, leaving nothing to inline. Verified post-rebuild: those pages were byte-identical pre/post #32.

Drop `Const_*` from `EXCLUDE_SYMBOLS` so each const half gets its own page (read-only methods become reachable via `Inherits Const_Foo` link), and revert `INLINE_INHERITED_MEMB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)